### PR TITLE
add an option to use non recursive sort

### DIFF
--- a/src/openga.hpp
+++ b/src/openga.hpp
@@ -279,6 +279,7 @@ public:
 	int N_threads;
 	bool user_request_stop;
 	long idle_delay_us;
+	bool use_quick_search = true;
 
 	function<void(thisGenerationType&)> calculate_IGA_total_fitness;
 	function<double(const thisChromosomeType&)> calculate_SO_total_fitness;
@@ -1075,7 +1076,17 @@ protected:
 		for(int i=0;i<N;i++)
 			gen.sorted_indices.push_back(i);
 
-		quicksort_indices_SO(gen.sorted_indices,gen,0,int(gen.sorted_indices.size())-1);
+		if (use_quick_search) {
+			quicksort_indices_SO(gen.sorted_indices,gen,0,int(gen.sorted_indices.size())-1);
+		} else {
+			struct {
+				bool operator()(thisGenerationType &gen, int a, int b) const
+				{
+					return gen.chromosomes[a].total_cost < gen.chromosomes[b].total_cost;
+				}
+			} customLess;
+			std::sort(gen.sorted_indices.begin(), gen.sorted_indices.end(), bind(customLess, gen, std::placeholders::_1, std::placeholders::_2));
+		}
 
 		vector<int> ranks;
 		ranks.assign(gen.chromosomes.size(),0);

--- a/src/openga.hpp
+++ b/src/openga.hpp
@@ -1076,16 +1076,17 @@ protected:
 		for(int i=0;i<N;i++)
 			gen.sorted_indices.push_back(i);
 
-		if (use_quick_search) {
+		if (use_quick_search)
+		{
 			quicksort_indices_SO(gen.sorted_indices,gen,0,int(gen.sorted_indices.size())-1);
-		} else {
-			struct {
-				bool operator()(thisGenerationType &gen, int a, int b) const
+		}
+		else
+		{
+			std::sort(gen.sorted_indices.begin(), gen.sorted_indices.end(),
+				[&gen](int a,int b)->bool
 				{
 					return gen.chromosomes[a].total_cost < gen.chromosomes[b].total_cost;
-				}
-			} customLess;
-			std::sort(gen.sorted_indices.begin(), gen.sorted_indices.end(), bind(customLess, gen, std::placeholders::_1, std::placeholders::_2));
+				});
 		}
 
 		vector<int> ranks;


### PR DESCRIPTION
This is a little bit slower but it does not stack overflow when population is huge (more than 6000 in my case). It also depend when the pivot is found.

With the std::sort, no recursion, so no stack issue