### PR TITLE
modified so that last_generation is not overwritten by an empty one.

### DIFF
--- a/src/openGA.hpp
+++ b/src/openGA.hpp
@@ -485,8 +485,8 @@ public:
 		{
 			generations_so_abs.push_back(thisGenSOAbs(new_generation));
 			report_generation(new_generation);
+			last_generation=new_generation;
 		}
-		last_generation=new_generation;
 
 		return stop_critera();
 	}


### PR DESCRIPTION
moved update of last_generation inside if(!user_request_stop) block
for solve_next_generation function

This should prevent last_generation instance from being overwritten by incomplete new_generation